### PR TITLE
Filter out already uploaded and created medias from the upload task

### DIFF
--- a/src/main/kotlin/br/com/afadc/folderstoalbumsconvertergooglephotos/controllers/UploadScreenController.kt
+++ b/src/main/kotlin/br/com/afadc/folderstoalbumsconvertergooglephotos/controllers/UploadScreenController.kt
@@ -322,6 +322,7 @@ class UploadScreenController(
             return
         }
 
+        val alreadyUploadedAndCreatedMediaPaths = appDatabase.getUploadedAndCreatedDbMediasPaths()
         val albums = ArrayList<Album>()
 
         for (selectedTreePath in selectedTreePaths) {
@@ -334,7 +335,7 @@ class UploadScreenController(
                 val nextNode = (albumEnumeration.nextElement() as DefaultMutableTreeNode)
                 val file = (nextNode.userObject as FileNodesCreator.FileNode).file
 
-                if (file.isFile) {
+                if (file.isFile && !alreadyUploadedAndCreatedMediaPaths.contains(file.absolutePath)) {
                     mediaFiles.add(Media(file))
                 }
             }

--- a/src/main/kotlin/br/com/afadc/folderstoalbumsconvertergooglephotos/db/AppDatabase.kt
+++ b/src/main/kotlin/br/com/afadc/folderstoalbumsconvertergooglephotos/db/AppDatabase.kt
@@ -3,8 +3,6 @@ package br.com.afadc.folderstoalbumsconvertergooglephotos.db
 import br.com.afadc.folderstoalbumsconvertergooglephotos.db.entities.DbAlbum
 import br.com.afadc.folderstoalbumsconvertergooglephotos.db.entities.DbMedia
 import java.io.File
-import java.lang.IllegalArgumentException
-import java.lang.RuntimeException
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.Types
@@ -152,6 +150,25 @@ class AppDatabase(private val dbDir: File) {
         }
     }
 
+    fun getUploadedAndCreatedDbMediasPaths(): ArrayList<String> {
+        val result = ArrayList<String>(1024)
+
+        val query = """
+           SELECT
+            ("${dbDir.absolutePath + "/"}" || path) as path
+            FROM
+            medias
+            WHERE is_uploaded_and_created = 1
+        """
+
+        val preparedStatement = conn.prepareStatement(query)
+        val rs = preparedStatement.executeQuery()
+        while (rs.next()) {
+            result.add(rs.getString("path"))
+        }
+
+        return result
+    }
 
     fun insertOrUpdateMedia(dbMedia: DbMedia) {
         if (getDbMediaByFile(File(dbDir, dbMedia.path)) == null) {


### PR DESCRIPTION
Not the ideal solution to deal with UI feedbacks, but it is a **fast and temporary** one.

If the user has a huge amount of medias on the selected directory, the start of the task might take a few seconds now and the UI will be frozen during that time.